### PR TITLE
Use a regex to search files for mangled symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,14 +1,177 @@
 [root]
 name = "rustfilt"
-version = "0.1.2-pre"
+version = "0.2.0"
 dependencies = [
- "rustc-demangle 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-demangle"
-version = "0.1.2"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "term_size"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-id"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum rustc-demangle 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "662b2795f21ff17df7c4c50c1d955c8b5fa9eaddd1cf1bb32f8de2372ffd989b"
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
+"checksum bitflags 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e1ab483fc81a8143faa7203c4a3c02888ebd1a782e37e41fa34753ba9a162"
+"checksum clap 2.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "74a80f603221c9cd9aa27a28f52af452850051598537bb6b359c38a7d61e5cda"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7291b1dd97d331f752620b02dfdbc231df7fc01bf282a00769e1cdb963c460dc"
+"checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
+"checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
+"checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
+"checksum term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "07b6c1ac5b3fffd75073276bca1ceed01f67a28537097a2a9539e116e50fb21a"
+"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
+"checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
+"checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8cdc8b93bd0198ed872357fb2e667f7125646b1762f16d60b2c96350d361897"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,22 @@ name = "rustfilt"
 description = "Demangle Rust symbol names"
 homepage = "https://github.com/luser/rustfilt"
 repository = "https://github.com/luser/rustfilt"
-version = "0.1.2-pre"
-authors = ["Ted Mielczarek <ted@mielczarek.org>"]
+version = "0.2.0"
+authors = ["Ted Mielczarek <ted@mielczarek.org>", "Nicholas Schlabach <Techcable@techcable.ent>"]
+readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-rustc-demangle = "0.1.2"
+rustc-demangle = "^0.1.4"
+lazy_static = "^0.2.4"
+regex = "^0.2.1"
 
+[dependencies.clap]
+version = "^2.21.1"
+# Exclude all optional features except wrap_help
+default-features = false
+features = ["wrap_help"]
+
+[profile.release]
+# Reduces binary size by 21%
+lto = true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 Demangle Rust symbol names using [rustc-demangle](https://github.com/alexcrichton/rustc-demangle). `rustfilt` works similarly to `c++filt`, in that it accepts mangled symbol names as command line arguments, and if none are provided it accepts mangled symbols from stdin. Demangled symbols are written to stdout.
+
+## Installation
+````bash
+cargo install rustfilt
+````
+
+## Usage
+To demangle a file, simply run:
+````bash
+rustfilt -i mangled.txt -o demangled.txt
+````
+Rustfilt can also accept data from stdin, and pipe to stdout:
+````
+curl example.com/mangled-symbols.txt | rustfilt | less
+````
+
+By default, rustfilt strips the generated 'hashes' from the mangled names.
+If these need to be kept, simply pass the `-h` option to rustfilt.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,35 +12,207 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate lazy_static;
+extern crate regex;
 extern crate rustc_demangle;
 
 use rustc_demangle::demangle;
+use regex::{Regex, Captures};
 
-use std::env;
-use std::io::{
-    self,
-    BufRead,
-    Write,
-};
+use std::borrow::Cow;
+use std::fmt::{Write as FmtWrite};
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, BufWriter, Write, stdin, stdout, stderr};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::process::exit;
 
-fn try_demangle<O : Write>(mut out: &mut O, maybe_symbol: Result<String, ()>) {
-    if let Ok(symbol) = maybe_symbol {
-        write!(out, "{}\n", demangle(&symbol)).unwrap();
+mod tests;
+
+lazy_static! {
+    // NOTE: Use [[:alnum::]] instead of \w to only match ASCII word characters, not unicode
+    static ref MANGLED_NAME_PATTERN: Regex = Regex::new(r"_ZN[\$\._[:alnum:]]*").unwrap();
+}
+
+#[inline] // Except for the nested functions (which don't count), this is a very small function
+pub fn demangle_line(line: &str, include_hash: bool) -> Cow<str> {
+    fn demangle_nohash(captures: &Captures) -> String {
+        let original = &captures[0];
+        // Allocate the buffer based on the assumption the output won't be longer than the input
+        let mut buf = String::with_capacity(original.len());
+        let demangled = demangle(original);
+         // Use alternate formatting to exclude the hash from the result
+        write!(buf, "{:#}", demangled).unwrap();
+        debug_assert!(buf.len() <= original.len(), "Output '{}' was longer than input '{}'", buf, original);
+        buf
+    }
+    fn demangle_with_hash(captures: &Captures) -> String {
+        let original = &captures[0];
+        // Allocate the buffer based on the assumption the output won't be longer than the input
+        let mut buf = String::with_capacity(original.len());
+        let demangled = demangle(original);
+        write!(buf, "{}", demangled).unwrap();
+        debug_assert!(buf.len() <= original.len(), "Output '{}' was longer than input '{}'", buf, original);
+        buf
+    }
+    MANGLED_NAME_PATTERN.replace_all(line, if include_hash { demangle_with_hash } else { demangle_nohash })
+}
+
+fn demangle_stream<R: BufRead, W: Write>(input: &mut R, output: &mut W, include_hash: bool) -> io::Result<()> {
+    let mut buf = String::new();
+    loop {
+        // NOTE: this is actually more efficient than lines(), since it re-uses the buffer
+        let num_bytes = input.read_line(&mut buf)?;
+        if num_bytes > 0 {
+            // NOTE: This includes the line-ending, and leaves it untouched
+            let demangled_line = demangle_line(&buf, include_hash).into_owned();
+            if cfg!(debug_assertions) {
+                debug_assert!(buf.ends_with('\n'), "No line ending in input!");
+                let line_ending = if buf.ends_with("\r\n") { "\r\n" } else { "\n" };
+                debug_assert!(demangled_line.ends_with(line_ending), "Demangled line has incorrect line ending");
+            }
+            output.write_all(&demangled_line.into_bytes())?;
+
+        } else {
+            return Ok(()); // Successfully hit EOF
+        }
+        buf.clear(); // Reset the buffer's position, without freeing it's underlying memory
+    }
+}
+
+enum InputType {
+    Stdin,
+    File(PathBuf)
+}
+
+impl InputType {
+    fn demangle(&self, output: OutputType, include_hash: bool) -> io::Result<()> {
+        // NOTE: This has to be seperated into two functions for generics
+        match *self {
+            InputType::Stdin => {
+                let stdin = stdin();
+                let mut lock = stdin.lock();
+                output.demangle_from(&mut lock, include_hash)
+            },
+            InputType::File(ref path) => output.demangle_from(&mut BufReader::new(File::open(path)?), include_hash)
+        }
+    }
+    fn validate(file: String) -> Result<(), String> {
+        file.parse::<InputType>().map(|_| ())
+    }
+}
+impl FromStr for InputType {
+    type Err = String;
+    fn from_str(file: &str) -> Result<InputType, String> {
+        if file == "-" {
+            Ok(InputType::Stdin)
+        } else {
+            let path = Path::new(&file);
+            if !path.is_file() {
+                if !path.exists() {
+                    Err(format!("{} doesn't exist", file))
+                } else {
+                    Err(format!("{} isn't a file", file))
+                }
+            } else {
+                Ok(InputType::File(PathBuf::from(path)))
+            }
+        }
+    }
+}
+
+enum OutputType {
+    Stdout,
+    File(PathBuf)
+}
+
+impl OutputType {
+    #[inline] // It's only used twice
+    fn demangle_from<I: io::BufRead>(&self, input: &mut I, include_hash: bool) -> io::Result<()> {
+        match *self {
+            OutputType::Stdout => {
+                let stdout = stdout();
+                let mut lock = stdout.lock();
+                demangle_stream(input, &mut lock, include_hash)
+            },
+            OutputType::File(ref path) => {
+                let file = File::create(path)?;
+                let mut buf = BufWriter::new(&file);
+                demangle_stream(input, &mut buf, include_hash)
+            }
+        }
+    }
+    fn demangle_names<S: AsRef<str>>(&self, names: &[S], include_hash: bool) -> io::Result<()> {
+        #[inline] // It's only used once ;)
+        fn demangle_names_to<S: AsRef<str>, O: io::Write>(names: &[S], output: &mut O, include_hash: bool) -> io::Result<()> {
+            for name in names {
+                let demangled = demangle(name.as_ref());
+                if include_hash {
+                    writeln!(output, "{}", demangled)?
+                } else {
+                    writeln!(output, "{:#}", demangled)?
+                };
+            }
+            Ok(())
+        }
+        match *self {
+            OutputType::Stdout => {
+                let stdout = stdout();
+                let mut lock = stdout.lock();
+                demangle_names_to(names, &mut lock, include_hash)
+            },
+            OutputType::File(ref path) => {
+                let file = File::create(path)?;
+                let mut buf = BufWriter::new(&file);
+                demangle_names_to(names, &mut buf, include_hash)
+            }
+        }
+    }
+    fn validate(file: String) -> Result<(), String> {
+        file.parse::<OutputType>().map(|_| ())
+    }
+}
+impl FromStr for OutputType {
+    type Err = String;
+    fn from_str(file: &str) -> Result<OutputType, String> {
+        if file == "-" {
+            Ok(OutputType::Stdout)
+        } else {
+            let path = Path::new(&file);
+            if path.exists() {
+                Err(format!("{} already exists", file))
+            } else {
+                Ok(OutputType::File(PathBuf::from(path)))
+            }
+        }
     }
 }
 
 fn main() {
-    let so = io::stdout();
-    let mut stdout = so.lock();
-    let mut printed = false;
-    for argument in env::args_os().skip(1) {
-        printed = true;
-        try_demangle(&mut stdout, argument.into_string().or(Err(())));
-    }
-    if !printed {
-        let si = io::stdin();
-        for line in si.lock().lines() {
-            try_demangle(&mut stdout, line.or(Err(())));
-        }
+    let args: clap::ArgMatches = clap_app!(rust_demangle =>
+        (version: crate_version!())
+        (author: crate_authors!())
+        (about: "Demangles names generated by the rust compiler")
+        (@arg INCLUDE_HASH: --include-hash --hash "Include the hashes in the demangled names")
+        (@arg INPUT: --input -i [FILE] default_value("-") {InputType::validate} "The input file to replace the mangled names in, or '-' for stdin")
+        (@arg OUTPUT: --output -o [FILE] default_value("-") {OutputType::validate} "The output file to emit the demangled names to, or '-' for stdout")
+        (@arg NAMES: ... [NAME] conflicts_with[INPUT] "The list of names to demangle")
+    ).get_matches();
+    let include_hash = args.is_present("INCLUDE_HASH");
+    let output = value_t!(args, "OUTPUT", OutputType).unwrap();
+    if let Some(names) = args.values_of("NAMES") {
+        output.demangle_names(&names.collect::<Vec<_>>(), include_hash).unwrap_or_else(|e| {
+            writeln!(stderr(), "Unable to demangle names: {}", e).unwrap();
+            exit(1);
+        })
+    } else {
+        let input = value_t!(args, "INPUT", InputType).unwrap();
+        input.demangle(output, include_hash).unwrap_or_else(|e| {
+            writeln!(stderr(), "Unable to demangle input: {}", e).unwrap();
+            exit(1);
+        })
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,68 @@
+#![cfg(test)]
+///! Tests demangle_line, based upon the assumption rustc_demangle works properly
+
+use rustc_demangle::demangle;
+use super::demangle_line;
+
+static MANGLED_NAMES: &'static [&'static str] = &[
+    "_ZN55_$LT$$RF$$u27$a$u20$T$u20$as$u20$core..fmt..Display$GT$3fmt17h510ed05e72307174E",
+    "_ZN7example4main17h0db00b8b32acffd5E",
+    "_ZN3std2io5stdio6_print17he48522be5b0a80d9E",
+    "_ZN3foo17h05af221e174051e9E",
+    "_ZN3foo20h05af221e174051e9abcE",
+    "_ZN3foo5h05afE",
+    "_ZN109_$LT$core..str..pattern..CharSearcher$LT$$u27$a$GT$$u20$as$u20$core..str..pattern..Searcher$LT$$u27$a$GT$$GT$10next_match17h9c8d80a58da7cd74E",
+    "_ZN84_$LT$core..iter..Map$LT$I$C$$u20$F$GT$$u20$as$u20$core..iter..iterator..Iterator$GT$4next17h98ea4751a6975428E",
+    "_ZN51_$LT$serde_json..read..IteratorRead$LT$Iter$GT$$GT$15parse_str_bytes17h8199b7867f1a334fE"
+];
+#[test]
+fn ignores_text() {
+    for text in &["boom de yada\tboom de yada\n", "bananas are fun for everyone"] {
+        assert_eq!(demangle_line(text, false), *text);
+        assert_eq!(demangle_line(text, true), *text);
+    }
+}
+
+#[test]
+fn standalone_demangles() {
+    for name in MANGLED_NAMES {
+        assert_eq!(demangle_line(name, true).as_ref(), &demangle(name).to_string());
+    }
+}
+
+#[test]
+fn standalone_demangles_nohash() {
+    for name in MANGLED_NAMES {
+        assert_eq!(demangle_line(name, false).as_ref(), &format!("{:#}", demangle(name)));
+    }
+}
+
+fn test_embedded_line_demangle<F1, F2>(line_demangler: F1, demangler: F2) where F1: Fn(&str) -> String, F2: Fn(&str) -> String {
+    for name in MANGLED_NAMES {
+        macro_rules! test_context {
+            ($context:expr) => (assert_eq!(line_demangler(&format!($context, name)), format!($context, demangler(name))))
+        }
+        // x86 ASM
+        test_context!("        lea     rax, [rip + {}]");
+        test_context!("        call    {}@PLT");
+        // perf script --no-demangle
+        test_context!("                  1a680e {} (/home/user/git/steven-rust/target/debug/steven)");
+        test_context!("                  20039f {} (/home/user/git/steven-rust/target/debug/steven)");
+        test_context!("                  1dade8 {} (/home/user/git/steven-rust/target/debug/steven)");
+        // Random unicode symbols
+        test_context!("J∆ƒƒ∆Ǥ{}∆ʓ∆ɲI∆ɳ");
+        // https://xkcd.com/1638/
+        test_context!(r#"cat out.txt | grep -o "\\\[[(].*\\\[{}\])][^)\]]*$""#);
+        test_context!(r"\\\\\\\\{}\\\\\\\\"); // Backslash to end all other text (twice)
+    }
+}
+
+#[test]
+fn embedded_demangle() {
+    test_embedded_line_demangle(|line| demangle_line(line, false).into_owned(), |name| format!("{:#}", demangle(name)));
+}
+
+#[test]
+fn embedded_demangle_nohash() {
+    test_embedded_line_demangle(|line| demangle_line(line, true).into_owned(), |name| demangle(name).to_string());
+}


### PR DESCRIPTION
This greatly expands the usability of the crate,
by allowing users to automatically demangle all symbols in a file.
This was already a feature of c++filt, but wasn't in rustfilt.

In addition, rustfilt can now strip hashes from the demangled symbols,
and does so by default. This is usually what the user wants, as it makes
the symbols more readable, but it can be disabled with the -h flag.

Thanks to the speed of the regex crate, this is _very_ fast.
To demangle a 69MB file took 0.5s, which is 6.8x faster than c++filt.

Since this is such a major change, I bumped the version to 0.2.0, and I suggest you do a release to cargo.