### PR TITLE
Simplify the demangling buffer management

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,7 @@ fn demangle_stream<R: BufRead, W: Write>(input: &mut R, output: &mut W, include_
         {
             // NOTE: This includes the line-ending, and leaves it untouched
             let demangled_line = demangle_line(&buf, include_hash);
-            if cfg!(debug_assertions) {
-                debug_assert!(buf.ends_with('\n'), "No line ending in input!");
+            if cfg!(debug_assertions) && buf.ends_with('\n') {
                 let line_ending = if buf.ends_with("\r\n") { "\r\n" } else { "\n" };
                 debug_assert!(demangled_line.ends_with(line_ending), "Demangled line has incorrect line ending");
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,8 @@ static MANGLED_NAMES: &'static [&'static str] = &[
     "_ZN3foo5h05afE",
     "_ZN109_$LT$core..str..pattern..CharSearcher$LT$$u27$a$GT$$u20$as$u20$core..str..pattern..Searcher$LT$$u27$a$GT$$GT$10next_match17h9c8d80a58da7cd74E",
     "_ZN84_$LT$core..iter..Map$LT$I$C$$u20$F$GT$$u20$as$u20$core..iter..iterator..Iterator$GT$4next17h98ea4751a6975428E",
-    "_ZN51_$LT$serde_json..read..IteratorRead$LT$Iter$GT$$GT$15parse_str_bytes17h8199b7867f1a334fE"
+    "_ZN51_$LT$serde_json..read..IteratorRead$LT$Iter$GT$$GT$15parse_str_bytes17h8199b7867f1a334fE",
+    "_ZN3std11collections4hash3map11RandomState3new4KEYS7__getit5__KEY17h1bc0dbd302b9f01bE"
 ];
 #[test]
 fn ignores_text() {


### PR DESCRIPTION
The prior code assumed that the demangled output was never longer than the
input.  This isn't true, as the newly-added test case demonstrates. It's
simpler to just let `format!` build the string for us, and still plenty
fast.  Fixes #3.

Also, when writing the output, there's no need to convert the regex-
replaced `Cow` to an owned string.  We can just write the bytes as-is.
And don't assert if the input "line" doesn't actually have a newline.